### PR TITLE
Create all-day events automatically based on available date info in Notion

### DIFF
--- a/src/CalendarClient.py
+++ b/src/CalendarClient.py
@@ -42,15 +42,20 @@ class CalendarClient:
 
         if (start_time == 'None'):
 
+            if_all_day = f"""
+            set isAllDay to true
+            """
+            cmd += f'{if_all_day}'
+
             if (end_date == 'None'):
 
-                cmd += f"""
-                tell application "Calendar"
-                    tell calendar "{self.name}"
-                        make new event with properties {{summary:"{title}", start date:theStartDate, allday event:true }}
-                    end tell
-                end tell
+                set_end_date = f"""
+                set theEndDate to current date
+                set day of theEndDate to {d}
+                set month of theEndDate to {m}
+                set year of theEndDate to {y}
                 """
+                cmd += f'{set_end_date}'
 
             else:
 
@@ -62,16 +67,13 @@ class CalendarClient:
                 set year of theEndDate to {y}
                 """
                 cmd += f'{set_end_date}'
-                
-                cmd += f"""
-                tell application "Calendar"
-                    tell calendar "{self.name}"
-                        make new event with properties {{summary:"{title}", start date:theStartDate, end date:theEndDate, allday event:true }}
-                    end tell
-                end tell
-                """
             
         else:
+
+            if_all_day = f"""
+            set isAllDay to false
+            """
+            cmd += f'{if_all_day}'
 
             h, m, s = start_time.split(':')
             set_start_hour = f"""
@@ -102,13 +104,14 @@ class CalendarClient:
             """
             cmd += f'{set_end_hour}'
 
-            cmd += f"""
-            tell application "Calendar"
-                tell calendar "{self.name}"
-                    make new event with properties {{summary:"{title}", start date:theStartDate, end date:theEndDate}}
-                end tell
+            
+        cmd += f"""
+        tell application "Calendar"
+            tell calendar "{self.name}"
+                make new event with properties {{summary:"{title}", start date:theStartDate, end date:theEndDate, allday event:isAllDay}}
             end tell
-            """
+        end tell
+        """
 
         r = applescript.run(cmd)
         if r.out:

--- a/src/CalendarClient.py
+++ b/src/CalendarClient.py
@@ -24,13 +24,14 @@ class CalendarClient:
         Args:
             title (str): title of notion card. Will be used for the calendar summary
             start_date (str) : format `%Y-%m-%d`
-            end_date (str) : format `%Y-%m-%d`
-            start_time (str) : format `%H:%M:%S`
-            end_time (str) : format `%H:%M:%S`
+            end_date (str) : format `%Y-%m-%d` or 'None'
+            start_time (str) : format `%H:%M:%S` or 'None'
+            end_time (str) : format `%H:%M:%S` or 'None'
         
         Returns:
             str : Id of the newly created event
         """
+
         y, m, d = start_date.split('-')
         cmd = f"""
         set theStartDate to current date
@@ -39,38 +40,76 @@ class CalendarClient:
         set year of theStartDate to {y}
         """
 
-        h, m, s = start_time.split(':')
-        set_start_hour = f"""
-        set hours of theStartDate to {h}
-        set minutes of theStartDate to {m}
-        set seconds of theStartDate to {s}
-        """
-        cmd += f'{set_start_hour}'
+        if (start_time == 'None'):
 
-        y, m, d = end_date.split('-')
-        set_end_date = f"""
-        set theEndDate to current date
-        set day of theEndDate to {d}
-        set month of theEndDate to {m}
-        set year of theEndDate to {y}
-        """
-        cmd += f'{set_end_date}'
+            if (end_date == 'None'):
 
-        h, m, s = end_time.split(':')
-        set_end_hour = f"""
-        set hours of theEndDate to {h}
-        set minutes of theEndDate to {m}
-        set seconds of theEndDate to {s}
-        """
-        cmd += f'{set_end_hour}'
+                cmd += f"""
+                tell application "Calendar"
+                    tell calendar "{self.name}"
+                        make new event with properties {{summary:"{title}", start date:theStartDate, allday event:true }}
+                    end tell
+                end tell
+                """
 
-        cmd += f"""
-        tell application "Calendar"
-            tell calendar "{self.name}"
-                make new event with properties {{summary:"{title}", start date:theStartDate, end date:theEndDate}}
+            else:
+
+                y, m, d = end_date.split('-')
+                set_end_date = f"""
+                set theEndDate to current date
+                set day of theEndDate to {d}
+                set month of theEndDate to {m}
+                set year of theEndDate to {y}
+                """
+                cmd += f'{set_end_date}'
+                
+                cmd += f"""
+                tell application "Calendar"
+                    tell calendar "{self.name}"
+                        make new event with properties {{summary:"{title}", start date:theStartDate, end date:theEndDate, allday event:true }}
+                    end tell
+                end tell
+                """
+            
+        else:
+
+            h, m, s = start_time.split(':')
+            set_start_hour = f"""
+            set hours of theStartDate to {h}
+            set minutes of theStartDate to {m}
+            set seconds of theStartDate to {s}
+            """
+            cmd += f'{set_start_hour}'
+
+            y, mo, d = start_date.split('-')
+
+            if (end_date != 'None'):
+                y, mo, d = end_date.split('-')
+                h, m, s = end_time.split(':')
+
+            set_end_date = f"""
+            set theEndDate to current date
+            set day of theEndDate to {d}
+            set month of theEndDate to {mo}
+            set year of theEndDate to {y}
+            """
+            cmd += f'{set_end_date}'
+
+            set_end_hour = f"""
+            set hours of theEndDate to {h}
+            set minutes of theEndDate to {m}
+            set seconds of theEndDate to {s}
+            """
+            cmd += f'{set_end_hour}'
+
+            cmd += f"""
+            tell application "Calendar"
+                tell calendar "{self.name}"
+                    make new event with properties {{summary:"{title}", start date:theStartDate, end date:theEndDate}}
+                end tell
             end tell
-        end tell
-        """
+            """
+
         r = applescript.run(cmd)
         if r.out:
             event_id = r.out.split()[2]

--- a/src/Database.py
+++ b/src/Database.py
@@ -37,7 +37,9 @@ class Database():
                 'id',
                 'last_edit',
                 'start_date',
+                'start_time',
                 'end_date',
+                'end_time',
                 'title',
                 'event_id'
             ]).set_index('id')
@@ -55,9 +57,10 @@ class Database():
             card_serie (pd.Series): series that corresponds to a Notion card
         """
         title = card_serie.title
-        start,end = str(card_serie.start_date),str(card_serie.end_date)
-        start_date,start_time = start.split()
-        end_date,end_time = end.split()
+        start_date = str(card_serie.start_date)
+        start_time = str(card_serie.start_time)
+        end_date = str(card_serie.end_date)
+        end_time = str(card_serie.end_time)
         return (title,start_date,end_date,start_time,end_time)
 
     def get_live(self)->pd.DataFrame:

--- a/src/notionClient.py
+++ b/src/notionClient.py
@@ -24,11 +24,7 @@ class Card:
         self.title = page.get('properties').get('Name').get('title')[0].get('plain_text')
         self.last_edited_time = self._convert_datetime(page.get('last_edited_time'))
         self.start_date = self._convert_datetime(page.get('properties').get('date').get('date').get('start'))
-        end_date = self._convert_datetime(page.get('properties').get('date').get('date').get('end'))
-        if end_date is None:
-            self.end_date = self.start_date
-        else:
-            self.end_date = end_date
+        self.end_date = self._convert_datetime(page.get('properties').get('date').get('date').get('end'))
 
     def to_dict(self) -> Dict:
         """Returns a representation of the card object as a Dict

--- a/src/notionClient.py
+++ b/src/notionClient.py
@@ -23,8 +23,8 @@ class Card:
         self._id = page['id']
         self.title = page.get('properties').get('Name').get('title')[0].get('plain_text')
         self.last_edited_time = self._convert_datetime(page.get('last_edited_time'))
-        self.start_date = self._convert_datetime(page.get('properties').get('date').get('date').get('start'))
-        self.end_date = self._convert_datetime(page.get('properties').get('date').get('date').get('end'))
+        (self.start_date, self.start_time) = self._convert_datetime(page.get('properties').get('date').get('date').get('start'))
+        (self.end_date, self.end_time) = self._convert_datetime(page.get('properties').get('date').get('date').get('end'))
 
     def to_dict(self) -> Dict:
         """Returns a representation of the card object as a Dict
@@ -36,7 +36,9 @@ class Card:
             'id': self._id,
             'last_edit': self.last_edited_time,
             'start_date': self.start_date,
+            'start_time': self.start_time,
             'end_date': self.end_date,
+            'end_time': self.end_time,
             'title': self.title
         }
         return _dict

--- a/src/notionClient.py
+++ b/src/notionClient.py
@@ -1,5 +1,5 @@
 import requests
-from typing import Dict, List
+from typing import Dict, List, Tuple
 from datetime import datetime
 import logging
 
@@ -44,23 +44,25 @@ class Card:
     def __repr__(self) -> str:
         return f"id : {self._id}\ntitle : {self.title}\nstart : {self.start_date}\nend : {self.end_date}\nlast edit : {self.last_edited_time}"
 
-    def _convert_datetime(self, notion_datetime: str) -> datetime:
+    def _convert_datetime(self, notion_datetime: str) -> Tuple:
         """Helpher function to normalize datetimes
 
         Args:
             notion_datetime (str): datetime
 
         Returns:
-            datetime: datetime
+            (date, time): (datetime.date, datetime.time)
         """
         if notion_datetime is None:
-            return notion_datetime
+            return (notion_datetime, notion_datetime)
         tmp = notion_datetime.split('T')
         if len(tmp) == 1:
-            return datetime.strptime(f'{tmp[0]} 00:00:00', '%Y-%m-%d %H:%M:%S')
+            fulldt = datetime.strptime(f'{tmp[0]} 00:00:00', '%Y-%m-%d %H:%M:%S')
+            return (fulldt.date, None)
         else:
             time = tmp[1][:8]
-            return datetime.strptime(f'{tmp[0]} {time}', '%Y-%m-%d %H:%M:%S')
+            fulldt = datetime.strptime(f'{tmp[0]} {time}', '%Y-%m-%d %H:%M:%S')
+            return (fulldt.date, fulldt.time)
 
 
 class NotionClient:

--- a/src/notionClient.py
+++ b/src/notionClient.py
@@ -60,11 +60,11 @@ class Card:
         tmp = notion_datetime.split('T')
         if len(tmp) == 1:
             fulldt = datetime.strptime(f'{tmp[0]} 00:00:00', '%Y-%m-%d %H:%M:%S')
-            return (fulldt.date, None)
+            return (fulldt.date(), None)
         else:
             time = tmp[1][:8]
             fulldt = datetime.strptime(f'{tmp[0]} {time}', '%Y-%m-%d %H:%M:%S')
-            return (fulldt.date, fulldt.time)
+            return (fulldt.date(), fulldt.time())
 
 
 class NotionClient:


### PR DESCRIPTION
These changes separate the date and time information available for each page/card in Notion, which can then be used to create more customized events in Calendar (e.g. all-day events).

Depending on whether the following pieces of datetime information exist for each page in the Notion database, the following events are created in Calendar:

* SD:
_all-day event on SD_
* SD + ST:
_ED, ET is set to SD, ST (zero-duration event)_
* SD + ED:
_all-day event, from SD to ED_
* SD + ST + ED + ET:
_event from SD, ST to ED, ET_


**Legend:**
SD - start date
ST - start time
ED - end date
ET - end time
